### PR TITLE
Correct logging severity

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,11 +21,13 @@ import (
 	"os"
 
 	"cloud.google.com/go/storage"
+
 	"github.com/gke-labs/multicluster-leader-election/controllers"
+	"github.com/gke-labs/multicluster-leader-election/pkg/logging"
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	// +kubebuilder:scaffold:imports
 )
@@ -42,12 +44,11 @@ func main() {
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
 	flag.Parse()
 
-	// Configure logging
-	opts := []zap.Opts{zap.UseDevMode(true)}
+	logLevel := zapcore.InfoLevel
 	if verbose {
-		opts = append(opts, zap.Level(zapcore.DebugLevel))
+		logLevel = zapcore.DebugLevel
 	}
-	ctrl.SetLogger(zap.New(opts...))
+	ctrl.SetLogger(logging.BuildLogger(os.Stderr, logLevel))
 
 	// Validate required flags
 	if gcsBucketName == "" {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ toolchain go1.24.6
 require (
 	cloud.google.com/go/storage v1.50.0
 	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/zapr v1.3.0
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.0
 	go.uber.org/zap v1.27.0
@@ -42,14 +44,12 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.5 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logging adds common logging hooks for cnrm applications
+package logging
+
+import (
+	"io"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap/zapcore"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// BuildLogger constructs a logr.Logger object that matches the standard
+// configuration across cnrm applications, writing to the io.Writer passed.
+func BuildLogger(output io.Writer, level zapcore.Level) logr.Logger {
+	encoderCfg := zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		LevelKey:       "severity",
+		NameKey:        "logger",
+		TimeKey:        "timestamp",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+	}
+	encoder := zapcore.NewJSONEncoder(encoderCfg)
+	return zapr.NewLogger(zap.NewRaw(zap.WriteTo(output), zap.Encoder(encoder), zap.Level(level)))
+}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/gke-labs/multicluster-leader-election/pkg/logging"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap/zapcore"
+)
+
+type ExampleError struct{}
+
+func (e *ExampleError) Error() string {
+	return "ExampleError"
+}
+
+// TestBuildLogger tests that buildLogger sets up log entries to be in JSON,
+// with fields compatible with GCP Cloud Logging, and that it respects the
+// configured log level.
+func TestBuildLogger(t *testing.T) {
+	testCases := []struct {
+		name    string
+		level   zapcore.Level
+		logFunc func(logger logr.Logger)
+		wantLog bool
+		want    map[string]interface{}
+	}{
+		{
+			name:    "info level, log info",
+			level:   zapcore.InfoLevel,
+			logFunc: func(logger logr.Logger) { logger.Info("info message") },
+			wantLog: true,
+			want: map[string]interface{}{
+				"msg":      "info message",
+				"severity": "info",
+			},
+		},
+		{
+			name:    "info level, log debug",
+			level:   zapcore.InfoLevel,
+			logFunc: func(logger logr.Logger) { logger.V(1).Info("debug message") },
+			wantLog: false,
+		},
+		{
+			name:    "debug level, log info",
+			level:   zapcore.DebugLevel,
+			logFunc: func(logger logr.Logger) { logger.Info("info message") },
+			wantLog: true,
+			want: map[string]interface{}{
+				"msg":      "info message",
+				"severity": "info",
+			},
+		},
+		{
+			name:    "debug level, log debug",
+			level:   zapcore.DebugLevel,
+			logFunc: func(logger logr.Logger) { logger.V(1).Info("debug message") },
+			wantLog: true,
+			want: map[string]interface{}{
+				"msg":      "debug message",
+				"severity": "debug",
+			},
+		},
+		{
+			name:  "info level, log error",
+			level: zapcore.InfoLevel,
+			logFunc: func(logger logr.Logger) {
+				logger.Error(&ExampleError{}, "error message")
+			},
+			wantLog: true,
+			want: map[string]interface{}{
+				"msg":      "error message",
+				"severity": "error",
+				"error":    "ExampleError",
+			},
+		},
+		{
+			name:  "debug level, log error",
+			level: zapcore.DebugLevel,
+			logFunc: func(logger logr.Logger) {
+				logger.Error(&ExampleError{}, "error message")
+			},
+			wantLog: true,
+			want: map[string]interface{}{
+				"msg":      "error message",
+				"severity": "error",
+				"error":    "ExampleError",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			logger := logging.BuildLogger(&buffer, tc.level)
+			tc.logFunc(logger)
+			logOutput := buffer.String()
+
+			if !tc.wantLog {
+				if logOutput != "" {
+					t.Errorf("expected no log output, but got: %s", logOutput)
+				}
+				return
+			}
+
+			if logOutput == "" {
+				t.Fatal("expected log output, but got none")
+			}
+
+			var got map[string]interface{}
+			if err := json.Unmarshal([]byte(logOutput), &got); err != nil {
+				t.Fatalf("failed to unmarshal log output: %v", err)
+			}
+
+			// Check for timestamp and remove it for comparison
+			if _, ok := got["timestamp"]; !ok {
+				t.Fatal("log message does not contain `timestamp`")
+			}
+			delete(got, "timestamp")
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected log output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The logging library being used (controller-runtime/pkg/log/zap) writes all its logs (both INFO and ERROR) to `stderr` by default: https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/log/zap/zap.go#L148-L150

Controller manager log: https://screenshot.googleplex.com/Bpy4R3qqUR9GmDk.png

