### PR TITLE
fix: make docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,18 +75,17 @@ docker-push:
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	@{ \
-	set -e ;
-	CONTROLLER_GEN_TMP_DIR=$(mktemp -d) ;
-	cd $CONTROLLER_GEN_TMP_DIR ;
-	go mod init tmp ;
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0 ;
-	rm -rf $CONTROLLER_GEN_TMP_DIR ;
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0 ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
-
 ##@ E2E Testing
 
 # Kind cluster names


### PR DESCRIPTION
I think the current controller-gen cmd is broken in the Makefile!

```
$ make docker-build && make docker-push
/bin/sh: -c: line 3: syntax error: unexpected end of file from `{' command on line 1
make: *** [Makefile:77: controller-gen] Error 2
```